### PR TITLE
Hotfix/cache recursion avoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Available additional settings that can be set to `UNICORN` dict in settings.py w
 
 ## Customization changelog
 
+### 0.60.0.2 - (2024-07-16)
+
+- Avoid recursion upon caching parent/child complex components with `pickle.dumps`
+
 ### 0.60.0.1 - (2024-03-29)
 
 - No customizations, just sync with main package.

--- a/django_unicorn/cacher.py
+++ b/django_unicorn/cacher.py
@@ -77,6 +77,10 @@ class CacheableComponent:
                 raise UnicornCacheError(
                     f"Cannot cache component '{type(component)}' because it is not picklable: {type(e)}: {e}"
                 ) from e
+            except RecursionError as e:
+                logger.warning(
+                    f"Cannot cache component '{type(component)}' because it is not picklable: {type(e)}: {e}"
+                )
 
         return self
 


### PR DESCRIPTION
Avoid recursion upon caching parent/child complex components with `pickle.dumps`